### PR TITLE
Mark HTTP request functions VOLATILE to prevent double execution on constant arguments

### DIFF
--- a/src/http_client_extension.cpp
+++ b/src/http_client_extension.cpp
@@ -409,31 +409,51 @@ namespace duckdb
             });
     }
 
+    // Every function here performs a network request — a side effect. Such
+    // functions MUST be VOLATILE, otherwise DuckDB's optimizer treats them as
+    // pure and may evaluate a call with all-constant arguments at plan time
+    // (constant folding) in addition to execution time. Concretely, nesting a
+    // call inside a larger constant expression — the common idiom
+    //   SELECT http_post('http://…', …)->>'access_token'
+    // — sends the request TWICE on one query. The query result is still a
+    // single correct row, so the duplicate is only visible in the server's
+    // logs; for non-idempotent endpoints (OAuth code exchange, webhooks,
+    // POSTs that create rows) it is a correctness bug. Marking the functions
+    // volatile (same class as random()/nextval()) pins one request per
+    // logical call. Verified: nested constant-arg http_post sends 2 without
+    // volatile, exactly 1 with it; column/bind arguments already sent once
+    // and are unaffected.
+    static ScalarFunction MakeVolatile(ScalarFunction fn)
+    {
+        fn.SetVolatile();
+        return fn;
+    }
+
     static void LoadInternal(ExtensionLoader &loader)
     {
         ScalarFunctionSet http_head("http_head");
-        http_head.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::JSON(), HTTPHeadRequestFunction));
+        http_head.AddFunction(MakeVolatile(ScalarFunction({LogicalType::VARCHAR}, LogicalType::JSON(), HTTPHeadRequestFunction)));
         loader.RegisterFunction(http_head);
 
         ScalarFunctionSet http_get("http_get");
-        http_get.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::JSON(), HTTPGetRequestFunction));
-        http_get.AddFunction(ScalarFunction(
+        http_get.AddFunction(MakeVolatile(ScalarFunction({LogicalType::VARCHAR}, LogicalType::JSON(), HTTPGetRequestFunction)));
+        http_get.AddFunction(MakeVolatile(ScalarFunction(
             {LogicalType::VARCHAR, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR),
              LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)},
-            LogicalType::JSON(), HTTPGetExRequestFunction));
+            LogicalType::JSON(), HTTPGetExRequestFunction)));
         loader.RegisterFunction(http_get);
 
         ScalarFunctionSet http_post("http_post");
-        http_post.AddFunction(ScalarFunction(
+        http_post.AddFunction(MakeVolatile(ScalarFunction(
             {LogicalType::VARCHAR, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR), LogicalType::JSON()},
-            LogicalType::JSON(), HTTPPostRequestFunction));
+            LogicalType::JSON(), HTTPPostRequestFunction)));
         loader.RegisterFunction(http_post);
 
         ScalarFunctionSet http_post_form("http_post_form");
-        http_post_form.AddFunction(ScalarFunction(
+        http_post_form.AddFunction(MakeVolatile(ScalarFunction(
             {LogicalType::VARCHAR, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR),
              LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)},
-            LogicalType::JSON(), HTTPPostFormRequestFunction));
+            LogicalType::JSON(), HTTPPostFormRequestFunction)));
         loader.RegisterFunction(http_post_form);
 
         QueryFarmSendTelemetry(loader, "http_client", "2026072501");


### PR DESCRIPTION
## Problem

When an HTTP function call with constant (literal) arguments is nested inside a larger expression, the request is sent **twice** per query:

```sql
LOAD json; LOAD http_client;
SELECT http_post('http://my-endpoint/token', headers => MAP {}, params => MAP {})->>'access_token';
-- my-endpoint receives TWO POST requests for this one call
```

The query result is still a single, correct row — the duplicate is only visible on the server side. For idempotent GETs that is silently doubled load; for side-effecting requests it is a correctness bug with no client-side symptom. The sharpest example is an OAuth authorization-code exchange: `http_post(token_url, ...)->>'access_token'` is exactly the idiom this fires on, and the second send replays a one-time code.

Two things narrow when it manifests:

- **Only constant arguments.** When any argument comes from a column or a prepared-statement bind, the request is sent once.
- **Only when nested in a larger constant expression.** A bare `SELECT http_post(...)` sends once; `http_post(...)->>'status'` sends twice.

## Root cause

On current `v1.5` (`f0fedb2`), `http_get` / `http_post` / `http_post_form` / `http_head` are registered with the default `FunctionStability::CONSISTENT`. That tells DuckDB's optimizer the function is pure, so an all-constant sub-expression is evaluated during constant folding at plan time — and evaluated again at execution time. Two evaluations → two network requests.

HTTP requests are side-effecting, so these functions should be `VOLATILE` (the same classification DuckDB uses for `random()`, `nextval()`, `uuid()`), which excludes them from constant folding and pins one evaluation per logical call.

`main` / `v1.5.5` already do this via `HttpFn` (`function.SetVolatile()`), landed with PR #36. This PR is the same flag on the four functions for the `v1.5` line only — not a reopen of #34 (that branch mixed telemetry, submodules, and a merge from `main`).

## Fix

`SetVolatile()` on each registered `ScalarFunction` (`http_head`, both `http_get` overloads, `http_post`, `http_post_form`). No telemetry, submodule, or Vector-API changes.

No behavior change for column/bind arguments (already one send); nested constant-argument calls now send once instead of twice.

## Verification

A local HTTP target that logs every inbound request, fired with the nested constant-arg call above (same query, same target, only the extension binary differs):

- **stock build:** target logs **2** requests
- **patched build (this PR):** target logs **1**

```bash
# terminal 1 — count inbound requests
node -e 'const fs=require("fs");require("http").createServer((q,s)=>{
  fs.appendFileSync("reqs.log",q.method+" "+q.url+"\n");
  q.on("end",()=>s.end("{}"))}).listen(18476,"127.0.0.1")'

# terminal 2 — note the ->> nesting; a bare SELECT http_post(...) does NOT reproduce
duckdb -unsigned -c "LOAD json; LOAD http_client;
  SELECT http_post('http://127.0.0.1:18476/token', headers => MAP {}, params => MAP {})->>'status';"
grep -c 'POST /token' reqs.log   # stock: 2, patched: 1
```
